### PR TITLE
Small features and fixes

### DIFF
--- a/chrome/EdgyArc-fr/main.css
+++ b/chrome/EdgyArc-fr/main.css
@@ -219,8 +219,12 @@
 :root:not([inDOMFullscreen="true"]) {
   #appcontent .browserStack {
     overflow: hidden !important;
-    border: var(--af-content-border) !important;
-    box-shadow: var(--af-content-shadow) !important;
+  }
+  @media not (-moz-bool-pref:"af.edgyarc.no-content-border") {
+    #appcontent .browserStack {
+      border: var(--af-content-border) !important;
+      box-shadow: var(--af-content-shadow) !important;
+    }
   }
 }
 

--- a/chrome/EdgyArc-fr/main.css
+++ b/chrome/EdgyArc-fr/main.css
@@ -150,12 +150,14 @@
 @media (-moz-bool-pref:"af.edgyarc.edge-sidebar") { 
 
   #sidebar-box {
-    border: var(--af-content-border) !important;
-    box-shadow: var(--af-content-shadow) !important;
+    box-shadow: var(--uc-tweak-rounded-corners-shadow) !important;
     border-radius: 6px !important;
     padding:0px !important;
+    @media not (-moz-bool-pref:"af.edgyarc.no-content-border") {
+      border: var(--af-content-border) !important;
+      box-shadow: var(--af-content-shadow) !important;
+    }
     @media (-moz-bool-pref:"af.edgyarc.macos-translucent") {
-     
       opacity: 0.6 !important;
        @media (-moz-bool-pref:"af.edgyarc.macos-more-translucent" ) {
          opacity:0.5 !important;

--- a/chrome/EdgyArc-fr/translucent-arc.css
+++ b/chrome/EdgyArc-fr/translucent-arc.css
@@ -1,64 +1,61 @@
 /*start minimal sidebar*/
 
-@media not (-moz-bool-pref:"af.edgyarc.edge-sidebar"){
-  
-  
+@media not (-moz-bool-pref: 'af.edgyarc.edge-sidebar') {
+  #sidebar-box {
+    background-color: transparent !important;
+    opacity: var(--af-minimal-opacity) !important;
+    margin: 0px !important;
+    padding: 0px !important;
+    &,
+    #sidebar {
+      border-radius: 0 0 0 0 !important;
+    }
+  }
+  :root[titlepreface='᠎'] {
     #sidebar-box {
-        background-color:transparent !important; 
-        opacity:var(--af-minimal-opacity) !important;
-     margin:0px !important;
-     padding:0px !important;
-      &, #sidebar {
-          border-radius:0 0 0 0 !important;
+      padding-left: 1px !important;
+      &:hover > #sidebar {
+        margin-left: var(--uc-tweak-rounded-corners-padding) !important;
+        margin-bottom: var(--uc-tweak-rounded-corners-padding) !important;
       }
-   }
-   :root[titlepreface="᠎"] {  
-      #sidebar-box {
-        padding-left:1px !important;
-      &:hover>#sidebar {
-   margin-left:var(--uc-tweak-rounded-corners-padding) !important;
-        margin-bottom:var(--uc-tweak-rounded-corners-padding) !important;
-     }
       &:hover::before {
         content: '';
-       display: block;
-       position: absolute;
-       top: 0; right: 0; bottom: 0; left: 0;
-       z-index: 0;
-       pointer-events: none;
-       background-color:var(--lwt-accent-color) !important;
-       opacity:var(--af-minimal-opacity) !important;
-     }
-   }
-     }
+        display: block;
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: 0;
+        pointer-events: none;
+        background-color: var(--lwt-accent-color) !important;
+        opacity: var(--af-minimal-opacity) !important;
+      }
+    }
+  }
   /* :root:not([customizing]):has(#sidebar-box:not([hidden])) {} */
-  :root:has(#sidebar-box:not([hidden])){
-  #appcontent .browserStack {
-     margin-left:0px !important;
-    }
-  }
-    :root:has(#sidebar-box[hidden]){
-  #appcontent .browserStack {
-     margin-left:8px !important;
+  :root:has(#sidebar-box:not([hidden])) {
+    /* This cancels left padding and margin on all immediate descendants (content, findbar, bottom-docked devtools) */
+    #appcontent .browserContainer > * {
+      padding-left: 0 !important;
+      margin-left: 0 !important;
     }
   }
 
-
-    
-  
-     #navigator-toolbox, .browserContainer {
-     &::before {
-        content: '';
-       display: block;
-       position: absolute;
-       top: 0; right: 0; bottom: 0; left: 0;
-       z-index: 0;
-       pointer-events: none;
-       background-color:var(--lwt-accent-color) !important;
-       opacity:var(--af-minimal-opacity) !important;
-     }
-   }
-
-
-  
-   }
+  #navigator-toolbox,
+  .browserContainer {
+    &::before {
+      content: '';
+      display: block;
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: 0;
+      pointer-events: none;
+      background-color: var(--lwt-accent-color) !important;
+      opacity: var(--af-minimal-opacity) !important;
+    }
+  }
+}

--- a/chrome/content/common.css
+++ b/chrome/content/common.css
@@ -1,101 +1,103 @@
 /* Edge-Frfox - content/common.css */
 
-/* colours */
-@-moz-document url-prefix(about:) {
-  :root {
-    --in-content-page-color: light-dark(#252525, #fff) !important;
-    --in-content-page-background: light-dark(#f7f7f7, #252525) !important;
-    --in-content-deemphasized-text: light-dark(#666, #bbb) !important;
-    --in-content-box-background: light-dark(#fff, #333) !important;
-    --in-content-box-background-odd: light-dark(rgb(0 0 0 / .05), rgb(255 255 255 / .05)) !important;
-    --in-content-box-info-background: light-dark(#f7f7f7, rgb(255 255 255 / 0.15)) !important;
-    --in-content-icon-color: light-dark(#666, #fff) !important;
-    --in-content-accent-color: light-dark(#006CBE, #75B6E8) !important;
-    --in-content-accent-color-active: light-dark(#1683D8, #4C98D1) !important;
-    --in-content-border-hover: light-dark(rgb(0 0 0 / .5), rgb(255 255 255 / .3)) !important;
-    --in-content-border-invalid: var(--red-50) !important;
-    --in-content-border-color: light-dark(#bebebe, rgb(255 255 255 / .2)) !important;
-    --in-content-error-text-color: light-dark(#FF848A, #FF9AA2) !important;
-    --in-content-link-color: light-dark(#0078D4, #75B6E8) !important;
-    --in-content-link-color-hover: light-dark(#006CBE, #63ADE5) !important;
-    --in-content-link-color-active: light-dark(#0749AC, #4C98D1) !important;
-    --in-content-link-color-visited: light-dark(#0078D4, #75B6E8) !important;
-    --link-color: var(--in-content-link-color) !important;
-    --link-color-hover: var(--in-content-link-color-hover) !important;
-    --link-color-active: var(--in-content-link-color-active) !important;
-    --link-color-visited: var(--in-content-link-color-visited) !important;
-    --in-content-button-text-color: var(--in-content-text-color) !important;
-    --in-content-button-text-color-hover: var(--in-content-text-color) !important;
-    --in-content-button-text-color-active: var(--in-content-button-text-color-hover) !important;
-    --in-content-button-background: light-dark(#EDEDED, #3B3B3B) !important;
-    --in-content-button-background-hover: light-dark(#e5e5e5, #545454) !important;
-    --in-content-button-background-active: light-dark(#d5d5d5, #606060) !important;
-    --in-content-primary-button-text-color: light-dark(#fff, #fff) !important;
-    --in-content-primary-button-background: light-dark(#0061e0, #006CBE) !important;
-    --in-content-primary-button-background-hover: light-dark(#0250bb, #0078D4) !important;
-    --in-content-primary-button-background-active: light-dark(#053e94, #005CA3) !important;
-    --color-accent-primary: light-dark(#0078D4, #006CBE) !important;
-    --color-accent-primary-hover: light-dark(#006CBE, #0078D4) !important;
-    --color-accent-primary-active: light-dark(#0749AC, #005CA3) !important;
-    --in-content-danger-button-background: light-dark(#DF4951, #E12424) !important;
-    --in-content-danger-button-background-hover: light-dark(#EA656C, #F94343) !important;
-    --in-content-danger-button-background-active: light-dark(#BB353C, #AA1E1E) !important;
-    --in-content-focus-outline-color: light-dark(rgb(0 85 215 / .5), #63ADE5) !important;
-    --focus-outline-color: var(--in-content-focus-outline-color) !important;
-    --in-content-table-background: light-dark(#f7f7f7, #252525) !important;
-    --in-content-text-color: var(--in-content-page-color) !important;
-    --border-interactive-color: light-dark(#929292, #858585) !important;
-    scrollbar-color:
-      light-dark(rgb(37 37 37 / .4), rgb(255 255 255 / .4))
-      light-dark(#f7f7f7, #252525) !important;
+@media (-moz-bool-pref: 'af.edgyarc.edge-styles') {
+  /* colours */
+  @-moz-document url-prefix(about:) {
+    :root {
+      --in-content-page-color: light-dark(#252525, #fff) !important;
+      --in-content-page-background: light-dark(#f7f7f7, #252525) !important;
+      --in-content-deemphasized-text: light-dark(#666, #bbb) !important;
+      --in-content-box-background: light-dark(#fff, #333) !important;
+      --in-content-box-background-odd: light-dark(rgb(0 0 0 / .05), rgb(255 255 255 / .05)) !important;
+      --in-content-box-info-background: light-dark(#f7f7f7, rgb(255 255 255 / 0.15)) !important;
+      --in-content-icon-color: light-dark(#666, #fff) !important;
+      --in-content-accent-color: light-dark(#006CBE, #75B6E8) !important;
+      --in-content-accent-color-active: light-dark(#1683D8, #4C98D1) !important;
+      --in-content-border-hover: light-dark(rgb(0 0 0 / .5), rgb(255 255 255 / .3)) !important;
+      --in-content-border-invalid: var(--red-50) !important;
+      --in-content-border-color: light-dark(#bebebe, rgb(255 255 255 / .2)) !important;
+      --in-content-error-text-color: light-dark(#FF848A, #FF9AA2) !important;
+      --in-content-link-color: light-dark(#0078D4, #75B6E8) !important;
+      --in-content-link-color-hover: light-dark(#006CBE, #63ADE5) !important;
+      --in-content-link-color-active: light-dark(#0749AC, #4C98D1) !important;
+      --in-content-link-color-visited: light-dark(#0078D4, #75B6E8) !important;
+      --link-color: var(--in-content-link-color) !important;
+      --link-color-hover: var(--in-content-link-color-hover) !important;
+      --link-color-active: var(--in-content-link-color-active) !important;
+      --link-color-visited: var(--in-content-link-color-visited) !important;
+      --in-content-button-text-color: var(--in-content-text-color) !important;
+      --in-content-button-text-color-hover: var(--in-content-text-color) !important;
+      --in-content-button-text-color-active: var(--in-content-button-text-color-hover) !important;
+      --in-content-button-background: light-dark(#EDEDED, #3B3B3B) !important;
+      --in-content-button-background-hover: light-dark(#e5e5e5, #545454) !important;
+      --in-content-button-background-active: light-dark(#d5d5d5, #606060) !important;
+      --in-content-primary-button-text-color: light-dark(#fff, #fff) !important;
+      --in-content-primary-button-background: light-dark(#0061e0, #006CBE) !important;
+      --in-content-primary-button-background-hover: light-dark(#0250bb, #0078D4) !important;
+      --in-content-primary-button-background-active: light-dark(#053e94, #005CA3) !important;
+      --color-accent-primary: light-dark(#0078D4, #006CBE) !important;
+      --color-accent-primary-hover: light-dark(#006CBE, #0078D4) !important;
+      --color-accent-primary-active: light-dark(#0749AC, #005CA3) !important;
+      --in-content-danger-button-background: light-dark(#DF4951, #E12424) !important;
+      --in-content-danger-button-background-hover: light-dark(#EA656C, #F94343) !important;
+      --in-content-danger-button-background-active: light-dark(#BB353C, #AA1E1E) !important;
+      --in-content-focus-outline-color: light-dark(rgb(0 85 215 / .5), #63ADE5) !important;
+      --focus-outline-color: var(--in-content-focus-outline-color) !important;
+      --in-content-table-background: light-dark(#f7f7f7, #252525) !important;
+      --in-content-text-color: var(--in-content-page-color) !important;
+      --border-interactive-color: light-dark(#929292, #858585) !important;
+      scrollbar-color:
+        light-dark(rgb(37 37 37 / .4), rgb(255 255 255 / .4))
+        light-dark(#f7f7f7, #252525) !important;
+    }
+
+    ::selection {
+      background-color: light-dark(#0078D4, #93B8E7);
+      color: light-dark(#fff, #000);
+    }
   }
 
-  ::selection {
-    background-color: light-dark(#0078D4, #93B8E7);
-    color: light-dark(#fff, #000);
-  }
-}
+  /* preferences */
+  @-moz-document url-prefix(about:preferences),
+  url-prefix(about:addons) {
+    .category[selected] {
+      position: relative !important;
+      border-radius: 4px !important;
+    }
 
-/* preferences */
-@-moz-document url-prefix(about:preferences),
-url-prefix(about:addons) {
-  .category[selected] {
-    position: relative !important;
-    border-radius: 4px !important;
-  }
+    .category[selected]:not(:hover, :active) {
+      background-color: var(--in-content-button-background) !important;
+    }
 
-  .category[selected]:not(:hover, :active) {
-    background-color: var(--in-content-button-background) !important;
-  }
+    .category[selected]::before {
+      content: "";
+      position: absolute;
+      inset-block: 0;
+      margin-block: auto;
+      height: 24px;
+      width: 3px;
+      left: 2px;
+      background-color: var(--in-content-accent-color);
+      border-radius: 3px;
+    }
 
-  .category[selected]::before {
-    content: "";
-    position: absolute;
-    inset-block: 0;
-    margin-block: auto;
-    height: 24px;
-    width: 3px;
-    left: 2px;
-    background-color: var(--in-content-accent-color);
-    border-radius: 3px;
-  }
+    button.tab-button:hover {
+      border-block-color: transparent var(--in-content-box-border-color) !important;
+    }
 
-  button.tab-button:hover {
-    border-block-color: transparent var(--in-content-box-border-color) !important;
-  }
+    button.tab-button[selected],
+    button.tab-button[selected]:hover {
+      border-block-color: transparent currentColor !important;
+    }
 
-  button.tab-button[selected],
-  button.tab-button[selected]:hover {
-    border-block-color: transparent currentColor !important;
-  }
-
-  .toggle-button {
-    --toggle-dot-margin: 4px !important;
-    --toggle-width: 40px !important;
-    --toggle-height: 20px !important;
-    --toggle-background-color: transparent !important;
-    --toggle-dot-background-color: var(--in-content-page-color) !important;
-    --toggle-dot-background-color-on-pressed: #fff !important;
-    --toggle-dot-transform-x: calc(var(--toggle-width) - 2 * var(--toggle-dot-margin) - 2 * var(--toggle-border-width) - var(--toggle-dot-width)) !important;
+    .toggle-button {
+      --toggle-dot-margin: 4px !important;
+      --toggle-width: 40px !important;
+      --toggle-height: 20px !important;
+      --toggle-background-color: transparent !important;
+      --toggle-dot-background-color: var(--in-content-page-color) !important;
+      --toggle-dot-background-color-on-pressed: #fff !important;
+      --toggle-dot-transform-x: calc(var(--toggle-width) - 2 * var(--toggle-dot-margin) - 2 * var(--toggle-border-width) - var(--toggle-dot-width)) !important;
+    }
   }
 }

--- a/chrome/content/common.css
+++ b/chrome/content/common.css
@@ -1,103 +1,101 @@
 /* Edge-Frfox - content/common.css */
 
-@media (-moz-bool-pref: 'af.edgyarc.edge-styles') {
-  /* colours */
-  @-moz-document url-prefix(about:) {
-    :root {
-      --in-content-page-color: light-dark(#252525, #fff) !important;
-      --in-content-page-background: light-dark(#f7f7f7, #252525) !important;
-      --in-content-deemphasized-text: light-dark(#666, #bbb) !important;
-      --in-content-box-background: light-dark(#fff, #333) !important;
-      --in-content-box-background-odd: light-dark(rgb(0 0 0 / .05), rgb(255 255 255 / .05)) !important;
-      --in-content-box-info-background: light-dark(#f7f7f7, rgb(255 255 255 / 0.15)) !important;
-      --in-content-icon-color: light-dark(#666, #fff) !important;
-      --in-content-accent-color: light-dark(#006CBE, #75B6E8) !important;
-      --in-content-accent-color-active: light-dark(#1683D8, #4C98D1) !important;
-      --in-content-border-hover: light-dark(rgb(0 0 0 / .5), rgb(255 255 255 / .3)) !important;
-      --in-content-border-invalid: var(--red-50) !important;
-      --in-content-border-color: light-dark(#bebebe, rgb(255 255 255 / .2)) !important;
-      --in-content-error-text-color: light-dark(#FF848A, #FF9AA2) !important;
-      --in-content-link-color: light-dark(#0078D4, #75B6E8) !important;
-      --in-content-link-color-hover: light-dark(#006CBE, #63ADE5) !important;
-      --in-content-link-color-active: light-dark(#0749AC, #4C98D1) !important;
-      --in-content-link-color-visited: light-dark(#0078D4, #75B6E8) !important;
-      --link-color: var(--in-content-link-color) !important;
-      --link-color-hover: var(--in-content-link-color-hover) !important;
-      --link-color-active: var(--in-content-link-color-active) !important;
-      --link-color-visited: var(--in-content-link-color-visited) !important;
-      --in-content-button-text-color: var(--in-content-text-color) !important;
-      --in-content-button-text-color-hover: var(--in-content-text-color) !important;
-      --in-content-button-text-color-active: var(--in-content-button-text-color-hover) !important;
-      --in-content-button-background: light-dark(#EDEDED, #3B3B3B) !important;
-      --in-content-button-background-hover: light-dark(#e5e5e5, #545454) !important;
-      --in-content-button-background-active: light-dark(#d5d5d5, #606060) !important;
-      --in-content-primary-button-text-color: light-dark(#fff, #fff) !important;
-      --in-content-primary-button-background: light-dark(#0061e0, #006CBE) !important;
-      --in-content-primary-button-background-hover: light-dark(#0250bb, #0078D4) !important;
-      --in-content-primary-button-background-active: light-dark(#053e94, #005CA3) !important;
-      --color-accent-primary: light-dark(#0078D4, #006CBE) !important;
-      --color-accent-primary-hover: light-dark(#006CBE, #0078D4) !important;
-      --color-accent-primary-active: light-dark(#0749AC, #005CA3) !important;
-      --in-content-danger-button-background: light-dark(#DF4951, #E12424) !important;
-      --in-content-danger-button-background-hover: light-dark(#EA656C, #F94343) !important;
-      --in-content-danger-button-background-active: light-dark(#BB353C, #AA1E1E) !important;
-      --in-content-focus-outline-color: light-dark(rgb(0 85 215 / .5), #63ADE5) !important;
-      --focus-outline-color: var(--in-content-focus-outline-color) !important;
-      --in-content-table-background: light-dark(#f7f7f7, #252525) !important;
-      --in-content-text-color: var(--in-content-page-color) !important;
-      --border-interactive-color: light-dark(#929292, #858585) !important;
-      scrollbar-color:
-        light-dark(rgb(37 37 37 / .4), rgb(255 255 255 / .4))
-        light-dark(#f7f7f7, #252525) !important;
-    }
-
-    ::selection {
-      background-color: light-dark(#0078D4, #93B8E7);
-      color: light-dark(#fff, #000);
-    }
+/* colours */
+@-moz-document url-prefix(about:) {
+  :root {
+    --in-content-page-color: light-dark(#252525, #fff) !important;
+    --in-content-page-background: light-dark(#f7f7f7, #252525) !important;
+    --in-content-deemphasized-text: light-dark(#666, #bbb) !important;
+    --in-content-box-background: light-dark(#fff, #333) !important;
+    --in-content-box-background-odd: light-dark(rgb(0 0 0 / .05), rgb(255 255 255 / .05)) !important;
+    --in-content-box-info-background: light-dark(#f7f7f7, rgb(255 255 255 / 0.15)) !important;
+    --in-content-icon-color: light-dark(#666, #fff) !important;
+    --in-content-accent-color: light-dark(#006CBE, #75B6E8) !important;
+    --in-content-accent-color-active: light-dark(#1683D8, #4C98D1) !important;
+    --in-content-border-hover: light-dark(rgb(0 0 0 / .5), rgb(255 255 255 / .3)) !important;
+    --in-content-border-invalid: var(--red-50) !important;
+    --in-content-border-color: light-dark(#bebebe, rgb(255 255 255 / .2)) !important;
+    --in-content-error-text-color: light-dark(#FF848A, #FF9AA2) !important;
+    --in-content-link-color: light-dark(#0078D4, #75B6E8) !important;
+    --in-content-link-color-hover: light-dark(#006CBE, #63ADE5) !important;
+    --in-content-link-color-active: light-dark(#0749AC, #4C98D1) !important;
+    --in-content-link-color-visited: light-dark(#0078D4, #75B6E8) !important;
+    --link-color: var(--in-content-link-color) !important;
+    --link-color-hover: var(--in-content-link-color-hover) !important;
+    --link-color-active: var(--in-content-link-color-active) !important;
+    --link-color-visited: var(--in-content-link-color-visited) !important;
+    --in-content-button-text-color: var(--in-content-text-color) !important;
+    --in-content-button-text-color-hover: var(--in-content-text-color) !important;
+    --in-content-button-text-color-active: var(--in-content-button-text-color-hover) !important;
+    --in-content-button-background: light-dark(#EDEDED, #3B3B3B) !important;
+    --in-content-button-background-hover: light-dark(#e5e5e5, #545454) !important;
+    --in-content-button-background-active: light-dark(#d5d5d5, #606060) !important;
+    --in-content-primary-button-text-color: light-dark(#fff, #fff) !important;
+    --in-content-primary-button-background: light-dark(#0061e0, #006CBE) !important;
+    --in-content-primary-button-background-hover: light-dark(#0250bb, #0078D4) !important;
+    --in-content-primary-button-background-active: light-dark(#053e94, #005CA3) !important;
+    --color-accent-primary: light-dark(#0078D4, #006CBE) !important;
+    --color-accent-primary-hover: light-dark(#006CBE, #0078D4) !important;
+    --color-accent-primary-active: light-dark(#0749AC, #005CA3) !important;
+    --in-content-danger-button-background: light-dark(#DF4951, #E12424) !important;
+    --in-content-danger-button-background-hover: light-dark(#EA656C, #F94343) !important;
+    --in-content-danger-button-background-active: light-dark(#BB353C, #AA1E1E) !important;
+    --in-content-focus-outline-color: light-dark(rgb(0 85 215 / .5), #63ADE5) !important;
+    --focus-outline-color: var(--in-content-focus-outline-color) !important;
+    --in-content-table-background: light-dark(#f7f7f7, #252525) !important;
+    --in-content-text-color: var(--in-content-page-color) !important;
+    --border-interactive-color: light-dark(#929292, #858585) !important;
+    scrollbar-color:
+      light-dark(rgb(37 37 37 / .4), rgb(255 255 255 / .4))
+      light-dark(#f7f7f7, #252525) !important;
   }
 
-  /* preferences */
-  @-moz-document url-prefix(about:preferences),
-  url-prefix(about:addons) {
-    .category[selected] {
-      position: relative !important;
-      border-radius: 4px !important;
-    }
+  ::selection {
+    background-color: light-dark(#0078D4, #93B8E7);
+    color: light-dark(#fff, #000);
+  }
+}
 
-    .category[selected]:not(:hover, :active) {
-      background-color: var(--in-content-button-background) !important;
-    }
+/* preferences */
+@-moz-document url-prefix(about:preferences),
+url-prefix(about:addons) {
+  .category[selected] {
+    position: relative !important;
+    border-radius: 4px !important;
+  }
 
-    .category[selected]::before {
-      content: "";
-      position: absolute;
-      inset-block: 0;
-      margin-block: auto;
-      height: 24px;
-      width: 3px;
-      left: 2px;
-      background-color: var(--in-content-accent-color);
-      border-radius: 3px;
-    }
+  .category[selected]:not(:hover, :active) {
+    background-color: var(--in-content-button-background) !important;
+  }
 
-    button.tab-button:hover {
-      border-block-color: transparent var(--in-content-box-border-color) !important;
-    }
+  .category[selected]::before {
+    content: "";
+    position: absolute;
+    inset-block: 0;
+    margin-block: auto;
+    height: 24px;
+    width: 3px;
+    left: 2px;
+    background-color: var(--in-content-accent-color);
+    border-radius: 3px;
+  }
 
-    button.tab-button[selected],
-    button.tab-button[selected]:hover {
-      border-block-color: transparent currentColor !important;
-    }
+  button.tab-button:hover {
+    border-block-color: transparent var(--in-content-box-border-color) !important;
+  }
 
-    .toggle-button {
-      --toggle-dot-margin: 4px !important;
-      --toggle-width: 40px !important;
-      --toggle-height: 20px !important;
-      --toggle-background-color: transparent !important;
-      --toggle-dot-background-color: var(--in-content-page-color) !important;
-      --toggle-dot-background-color-on-pressed: #fff !important;
-      --toggle-dot-transform-x: calc(var(--toggle-width) - 2 * var(--toggle-dot-margin) - 2 * var(--toggle-border-width) - var(--toggle-dot-width)) !important;
-    }
+  button.tab-button[selected],
+  button.tab-button[selected]:hover {
+    border-block-color: transparent currentColor !important;
+  }
+
+  .toggle-button {
+    --toggle-dot-margin: 4px !important;
+    --toggle-width: 40px !important;
+    --toggle-height: 20px !important;
+    --toggle-background-color: transparent !important;
+    --toggle-dot-background-color: var(--in-content-page-color) !important;
+    --toggle-dot-background-color-on-pressed: #fff !important;
+    --toggle-dot-transform-x: calc(var(--toggle-width) - 2 * var(--toggle-dot-margin) - 2 * var(--toggle-border-width) - var(--toggle-dot-width)) !important;
   }
 }

--- a/chrome/content/newtab.css
+++ b/chrome/content/newtab.css
@@ -1,395 +1,393 @@
 /* Edge-Frfox - content/newtab.css */
 
-@media (-moz-bool-pref: 'af.edgyarc.edge-styles') {
-  @-moz-document url-prefix("about:newtab"),
-  url-prefix("about:home"),
-  url-prefix("about:firefoxview") {
-    :root:not([lwt-newtab], [lwt-newtab-brighttext]) {
-      --newtab-background-color: #F7F7F7 !important;
-      --newtab-background-color-secondary: #fff !important;
-      --newtab-text-primary-color: #252525 !important;
-      --newtab-primary-action-background: #0078D4 !important;
-      --newtab-text-secondary-color: color-mix(in srgb, var(--newtab-text-primary-color) 80%, transparent) !important;
-      --newtab-element-hover-color: color-mix(in srgb, var(--newtab-background-color) 95%, #000) !important;
-      --newtab-element-active-color: color-mix(in srgb, var(--newtab-background-color) 90%, #000) !important;
-      --newtab-element-secondary-color: color-mix(in srgb, currentColor 5%, transparent) !important;
-      --newtab-element-secondary-hover-color: color-mix(in srgb, currentColor 12%, transparent) !important;
-      --newtab-element-secondary-active-color: color-mix(in srgb, currentColor 25%, transparent) !important;
-      --newtab-primary-element-hover-color: color-mix(in srgb, var(--newtab-primary-action-background) 90%, #000) !important;
-      --newtab-primary-element-active-color: color-mix(in srgb, var(--newtab-primary-action-background) 80%, #000) !important;
-      --newtab-primary-element-text-color: #fff !important;
-      --newtab-primary-action-background-dimmed: color-mix(in srgb, var(--newtab-primary-action-background) 25%, transparent) !important;
-      --newtab-border-color: color-mix(in srgb, var(--newtab-background-color) 75%, #000) !important;
-      --newtab-wordmark-color: #737373 !important;
-      --newtab-status-success: #50B080 !important;
-      --newtab-status-error: #FF848A !important;
-      --newtab-inner-box-shadow-color: rgb(0 0 0 / .1) !important;
-      --newtab-overlay-color: color-mix(in srgb, var(--newtab-background-color) 85%, transparent) !important;
-      --newtab-text-emphasis-background: #FFED32 !important;
-      --newtab-text-emphasis-text-color: #000 !important;
-      --newtab-textbox-focus-color: var(--newtab-primary-action-background) !important;
-      --newtab-textbox-focus-boxshadow: 0 0 0 1px var(--newtab-primary-action-background), 0 0 0 4px rgba(var(--newtab-primary-action-background), 0.3) !important;
-      --newtab-button-secondary-color: inherit !important;
+@-moz-document url-prefix("about:newtab"),
+url-prefix("about:home"),
+url-prefix("about:firefoxview") {
+  :root:not([lwt-newtab], [lwt-newtab-brighttext]) {
+    --newtab-background-color: #F7F7F7 !important;
+    --newtab-background-color-secondary: #fff !important;
+    --newtab-text-primary-color: #252525 !important;
+    --newtab-primary-action-background: #0078D4 !important;
+    --newtab-text-secondary-color: color-mix(in srgb, var(--newtab-text-primary-color) 80%, transparent) !important;
+    --newtab-element-hover-color: color-mix(in srgb, var(--newtab-background-color) 95%, #000) !important;
+    --newtab-element-active-color: color-mix(in srgb, var(--newtab-background-color) 90%, #000) !important;
+    --newtab-element-secondary-color: color-mix(in srgb, currentColor 5%, transparent) !important;
+    --newtab-element-secondary-hover-color: color-mix(in srgb, currentColor 12%, transparent) !important;
+    --newtab-element-secondary-active-color: color-mix(in srgb, currentColor 25%, transparent) !important;
+    --newtab-primary-element-hover-color: color-mix(in srgb, var(--newtab-primary-action-background) 90%, #000) !important;
+    --newtab-primary-element-active-color: color-mix(in srgb, var(--newtab-primary-action-background) 80%, #000) !important;
+    --newtab-primary-element-text-color: #fff !important;
+    --newtab-primary-action-background-dimmed: color-mix(in srgb, var(--newtab-primary-action-background) 25%, transparent) !important;
+    --newtab-border-color: color-mix(in srgb, var(--newtab-background-color) 75%, #000) !important;
+    --newtab-wordmark-color: #737373 !important;
+    --newtab-status-success: #50B080 !important;
+    --newtab-status-error: #FF848A !important;
+    --newtab-inner-box-shadow-color: rgb(0 0 0 / .1) !important;
+    --newtab-overlay-color: color-mix(in srgb, var(--newtab-background-color) 85%, transparent) !important;
+    --newtab-text-emphasis-background: #FFED32 !important;
+    --newtab-text-emphasis-text-color: #000 !important;
+    --newtab-textbox-focus-color: var(--newtab-primary-action-background) !important;
+    --newtab-textbox-focus-boxshadow: 0 0 0 1px var(--newtab-primary-action-background), 0 0 0 4px rgba(var(--newtab-primary-action-background), 0.3) !important;
+    --newtab-button-secondary-color: inherit !important;
+  }
+
+  :root:not([style*="color"])[lwt-newtab-brighttext] {
+    --newtab-background-color: #252525 !important;
+    --newtab-background-color-secondary: #4A4A4A !important;
+    --newtab-text-primary-color: #fff !important;
+    --newtab-primary-action-background: #75B6E8 !important;
+    --newtab-element-hover-color: color-mix(in srgb, var(--newtab-background-color) 95%, #FFF) !important;
+    --newtab-element-active-color: color-mix(in srgb, var(--newtab-background-color) 90%, #FFF) !important;
+    --newtab-element-secondary-color: color-mix(in srgb, currentColor 10%, transparent) !important;
+    --newtab-element-secondary-hover-color: color-mix(in srgb, currentColor 17%, transparent) !important;
+    --newtab-element-secondary-active-color: color-mix(in srgb, currentColor 30%, transparent) !important;
+    --newtab-border-color: color-mix(in srgb, var(--newtab-background-color) 75%, #FFF) !important;
+    --newtab-primary-element-text-color: #252525 !important;
+    --newtab-wordmark-color: #fff !important;
+    --newtab-status-success: #50B080 !important;
+  }
+
+  /* Custom GTK colours. */
+  @media (-moz-gtk-csd-available) {
+    :root:not([lwt-newtab]):not([style*="color"]) {
+      /* Colour adjusted for readability. */
+      --uc-accent-adjusted: light-dark(color-mix(in oklch, AccentColor 92%, black), color-mix(in oklch, AccentColor 60%, white));
+      --newtab-background-color: light-dark(-moz-dialog, color-mix(in srgb, -moz-dialog 82%, black)) !important;
+      --newtab-background-color-secondary: light-dark(Field, color-mix(in srgb, -moz-dialog 86%, white)) !important;
+      --newtab-text-primary-color: -moz-dialogtext !important;
+      --newtab-wordmark-color: light-dark(color-mix(in srgb, -moz-dialogtext 65%, transparent), -moz-dialogtext) !important;
+      --newtab-primary-action-background: var(--uc-accent-adjusted) !important;
+    }
+  }
+
+  /* Adjustments for themes. */
+  :root[style*="--newtab-background-color"] {
+    /* Make the Firefox logo workmark follow text colour. */
+    --newtab-wordmark-color: color-mix(in srgb, var(--newtab-text-primary-color) 60%, var(--newtab-background-color)) !important;
+
+    /* If there is no secondary background, create one from other colours. */
+    &:not([style*="--newtab-background-color-secondary"]) {
+      --newtab-background-color-secondary: color-mix(in srgb, var(--newtab-background-color) 15%, white) !important;
     }
 
-    :root:not([style*="color"])[lwt-newtab-brighttext] {
-      --newtab-background-color: #252525 !important;
-      --newtab-background-color-secondary: #4A4A4A !important;
-      --newtab-text-primary-color: #fff !important;
-      --newtab-primary-action-background: #75B6E8 !important;
-      --newtab-element-hover-color: color-mix(in srgb, var(--newtab-background-color) 95%, #FFF) !important;
-      --newtab-element-active-color: color-mix(in srgb, var(--newtab-background-color) 90%, #FFF) !important;
-      --newtab-element-secondary-color: color-mix(in srgb, currentColor 10%, transparent) !important;
-      --newtab-element-secondary-hover-color: color-mix(in srgb, currentColor 17%, transparent) !important;
-      --newtab-element-secondary-active-color: color-mix(in srgb, currentColor 30%, transparent) !important;
-      --newtab-border-color: color-mix(in srgb, var(--newtab-background-color) 75%, #FFF) !important;
-      --newtab-primary-element-text-color: #252525 !important;
-      --newtab-wordmark-color: #fff !important;
-      --newtab-status-success: #50B080 !important;
-    }
-
-    /* Custom GTK colours. */
-    @media (-moz-gtk-csd-available) {
-      :root:not([lwt-newtab]):not([style*="color"]) {
-        /* Colour adjusted for readability. */
-        --uc-accent-adjusted: light-dark(color-mix(in oklch, AccentColor 92%, black), color-mix(in oklch, AccentColor 60%, white));
-        --newtab-background-color: light-dark(-moz-dialog, color-mix(in srgb, -moz-dialog 82%, black)) !important;
-        --newtab-background-color-secondary: light-dark(Field, color-mix(in srgb, -moz-dialog 86%, white)) !important;
-        --newtab-text-primary-color: -moz-dialogtext !important;
-        --newtab-wordmark-color: light-dark(color-mix(in srgb, -moz-dialogtext 65%, transparent), -moz-dialogtext) !important;
-        --newtab-primary-action-background: var(--uc-accent-adjusted) !important;
-      }
-    }
-
-    /* Adjustments for themes. */
-    :root[style*="--newtab-background-color"] {
+    /* Dark adjustments for themes. */
+    &[lwt-newtab-brighttext] {
       /* Make the Firefox logo workmark follow text colour. */
-      --newtab-wordmark-color: color-mix(in srgb, var(--newtab-text-primary-color) 60%, var(--newtab-background-color)) !important;
+      --newtab-wordmark-color: var(--newtab-text-primary-color) !important;
 
       /* If there is no secondary background, create one from other colours. */
       &:not([style*="--newtab-background-color-secondary"]) {
-        --newtab-background-color-secondary: color-mix(in srgb, var(--newtab-background-color) 15%, white) !important;
+        --newtab-background-color-secondary: color-mix(in srgb, var(--newtab-text-primary-color) 15%, var(--newtab-background-color)) !important;
       }
+    }
+  }
+}
 
-      /* Dark adjustments for themes. */
-      &[lwt-newtab-brighttext] {
-        /* Make the Firefox logo workmark follow text colour. */
-        --newtab-wordmark-color: var(--newtab-text-primary-color) !important;
+@-moz-document url-prefix("about:newtab"),
+url-prefix("about:home") {
+  /* Enforce system font selection. */
+  :where(body) {
+    font-family: system-ui !important;
+  }
 
-        /* If there is no secondary background, create one from other colours. */
-        &:not([style*="--newtab-background-color-secondary"]) {
-          --newtab-background-color-secondary: color-mix(in srgb, var(--newtab-text-primary-color) 15%, var(--newtab-background-color)) !important;
-        }
+  /* Hide pin icons. */
+  .icon.icon-pin-small {
+    display: none !important;
+  }
+
+  /* Unpinned sites have lower opacity titles. */
+  .top-site-button .title:not(.pinned) {
+    opacity: 0.7 !important;
+  }
+
+  /* Search bar. */
+  .search-wrapper {
+    & .search-handoff-button {
+      border-radius: 99px !important;
+      background-position: 12px !important;
+      padding-inline-start: 48px !important;
+      white-space: nowrap !important;
+      text-overflow: ellipsis !important;
+      --elevation: 4;
+      box-shadow:
+        0 0 calc((var(--elevation) * 0.225px) + 2px) rgb(0 0 0 / .11),
+        0 calc(var(--elevation) * 0.4px) calc((var(--elevation) * 0.9px)) rgb(0 0 0 / .13) !important;
+
+      &:hover {
+        --elevation: 6;
+      }
+    }
+
+    & .search-inner-wrapper {
+      min-height: 44px !important;
+    }
+
+    &.fake-focus:not(.search.disabled) .search-handoff-button {
+      border-color: transparent !important;
+      outline: 2px solid var(--newtab-primary-action-background) !important;
+      outline-offset: -1px !important;
+    }
+
+    &.search-disabled .search-handoff-button {
+      opacity: 0 !important;
+    }
+
+    .search-handoff-button .fake-caret {
+      inset-inline-start: 48px !important;
+      top: 13px !important;
+    }
+
+    @media (height > 700px) {
+      .fixed-search & {
+        padding: 15px 0 !important;
+        min-height: auto !important;
+        border-bottom: none !important;
       }
     }
   }
 
-  @-moz-document url-prefix("about:newtab"),
-  url-prefix("about:home") {
-    /* Enforce system font selection. */
-    :where(body) {
-      font-family: system-ui !important;
+  .fake-textbox {
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+  }
+
+  .outer-wrapper.only-search {
+    display: flex !important;
+    padding: 30px !important;
+  }
+
+  /* Sticky search bar header when scrolling. */
+  @media (height > 700px) {
+    body:not(.inline-onboarding) .fixed-search.visible-logo main {
+      padding-top: 246px !important;
+
+      @media (-moz-bool-pref: "uc.tweak.hide-newtab-logo") {
+        padding-top: 82px !important;
+      }
+    }
+  }
+
+  .icon-settings {
+    background-image: url("../icons/settings.svg") !important;
+  }
+
+  /* Top sites tiles. */
+  .top-site-outer {
+    & .tile {
+      border-radius: 12px !important;
+      height: 44px !important;
+      width: 44px !important;
+      box-shadow: rgb(0 0 0 / 0.1) 0px 2px 4px !important;
+
+      & .icon-wrapper {
+        border-radius: 4px !important;
+        width: 24px !important;
+        height: 24px !important;
+
+        &.letter-fallback::before {
+          font-size: 32px !important;
+        }
+      }
     }
 
-    /* Hide pin icons. */
-    .icon.icon-pin-small {
+    & .default-icon,
+    & .search-topsite {
+      background-size: 16px !important;
+      height: 24px !important;
+      width: 24px !important;
+    }
+  }
+
+  /* Recent activity / Pocket cards */
+  .card-outer {
+    --uc-border-radius: 8px;
+
+    &,
+    & .card,
+    & .ds-card-grid.ds-card-grid-border .ds-card:not(.placeholder) {
+      border-radius: var(--uc-border-radius) !important;
+    }
+
+    & .card,
+    & .ds-card-grid.ds-card-grid-border .ds-card:not(.placeholder) {
+      box-shadow:
+        rgb(0 0 0 / 0.14) 0px 1px 2px,
+        rgb(0 0 0 / 0.12) 0px 0px 2px !important;
+    }
+
+    & .card-preview-image-outer,
+    & .ds-card-grid.ds-card-grid-border .ds-card:not(.placeholder) .img-wrapper .img img {
+      border-radius: var(--uc-border-radius) var(--uc-border-radius) 0 0 !important
+    }
+  }
+
+  /* Add background & adjust padding for Recent activity & Pocket section. */
+  .collapsible-section:not(.top-sites) {
+    background-color: var(--newtab-background-color) !important;
+    border-radius: 12px !important;
+    padding: 10px 20px 20px !important;
+
+    & .section-list {
+      gap: 12px !important;
+    }
+  }
+
+  @media (-moz-bool-pref: "uc.tweak.hide-newtab-logo") {
+    .logo-and-wordmark {
       display: none !important;
     }
 
-    /* Unpinned sites have lower opacity titles. */
-    .top-site-button .title:not(.pinned) {
-      opacity: 0.7 !important;
+    .outer-wrapper:not(.fixed-search) .search-wrapper {
+      padding-top: 0 !important;
     }
+  }
+}
 
-    /* Search bar. */
-    .search-wrapper {
-      & .search-handoff-button {
-        border-radius: 99px !important;
-        background-position: 12px !important;
-        padding-inline-start: 48px !important;
-        white-space: nowrap !important;
-        text-overflow: ellipsis !important;
-        --elevation: 4;
-        box-shadow:
-          0 0 calc((var(--elevation) * 0.225px) + 2px) rgb(0 0 0 / .11),
-          0 calc(var(--elevation) * 0.4px) calc((var(--elevation) * 0.9px)) rgb(0 0 0 / .13) !important;
+/* private browsing newtab */
+@-moz-document url-prefix(about:privatebrowsing) {
+  :root {
+    --uc-wordmark-color: light-dark(#737373, #fff);
+    --uc-background-color-secondary: light-dark(#fff, #4a4a4a);
 
-        &:hover {
-          --elevation: 6;
-        }
+    @media (-moz-bool-pref: "browser.theme.dark-private-windows") {
+      color-scheme: dark !important;
+    }
+  }
+
+  /* Custom GTK colours. */
+  @media (-moz-gtk-csd-available) {
+    :root:not([lwt-newtab]):not([style*="color"]) {
+      /* Colour adjusted for readability. */
+      --uc-accent-adjusted: light-dark(color-mix(in oklch, AccentColor 92%, black), color-mix(in oklch, AccentColor 60%, white));
+      --in-content-page-background: light-dark(-moz-dialog, color-mix(in srgb, -moz-dialog 82%, black)) !important;
+      --uc-background-color-secondary: light-dark(Field, color-mix(in srgb, -moz-dialog 86%, white)) !important;
+      --in-content-page-color: -moz-dialogtext !important;
+      --in-content-focus-outline-color: var(--uc-accent-adjusted) !important;
+    }
+  }
+
+  /* Private browsing search bar. */
+  .search-inner-wrapper {
+    height: 44px !important;
+    
+    .search-handoff-button,
+    .search-handoff-button:active,
+    .search-handoff-button:enabled:hover:active {
+      background-color: var(--uc-background-color-secondary) !important;
+      border: 0 !important;
+      border-radius: 99px !important;
+      padding-inline-start: 48px !important;
+      --elevation: 4;
+      box-shadow:
+      0 0 calc((var(--elevation) * 0.225px) + 2px) rgb(0 0 0 / .11),
+      0 calc(var(--elevation) * 0.4px) calc((var(--elevation) * 0.9px)) rgb(0 0 0 / .13) !important;
+      
+      &:hover {
+        --elevation: 6;
       }
-
-      & .search-inner-wrapper {
-        min-height: 44px !important;
-      }
-
-      &.fake-focus:not(.search.disabled) .search-handoff-button {
-        border-color: transparent !important;
-        outline: 2px solid var(--newtab-primary-action-background) !important;
+      
+      &.focused:not(.disabled) {
+        box-shadow: none !important;
+        outline: 2px solid var(--in-content-focus-outline-color) !important;
         outline-offset: -1px !important;
       }
-
-      &.search-disabled .search-handoff-button {
+      
+      &.disabled {
         opacity: 0 !important;
       }
-
-      .search-handoff-button .fake-caret {
-        inset-inline-start: 48px !important;
-        top: 13px !important;
-      }
-
-      @media (height > 700px) {
-        .fixed-search & {
-          padding: 15px 0 !important;
-          min-height: auto !important;
-          border-bottom: none !important;
-        }
-      }
-    }
-
-    .fake-textbox {
-      overflow: hidden !important;
-      text-overflow: ellipsis !important;
-    }
-
-    .outer-wrapper.only-search {
-      display: flex !important;
-      padding: 30px !important;
-    }
-
-    /* Sticky search bar header when scrolling. */
-    @media (height > 700px) {
-      body:not(.inline-onboarding) .fixed-search.visible-logo main {
-        padding-top: 246px !important;
-
-        @media (-moz-bool-pref: "uc.tweak.hide-newtab-logo") {
-          padding-top: 82px !important;
-        }
-      }
-    }
-
-    .icon-settings {
-      background-image: url("../icons/settings.svg") !important;
-    }
-
-    /* Top sites tiles. */
-    .top-site-outer {
-      & .tile {
-        border-radius: 12px !important;
-        height: 44px !important;
-        width: 44px !important;
-        box-shadow: rgb(0 0 0 / 0.1) 0px 2px 4px !important;
-
-        & .icon-wrapper {
-          border-radius: 4px !important;
-          width: 24px !important;
-          height: 24px !important;
-
-          &.letter-fallback::before {
-            font-size: 32px !important;
-          }
-        }
-      }
-
-      & .default-icon,
-      & .search-topsite {
-        background-size: 16px !important;
-        height: 24px !important;
-        width: 24px !important;
-      }
-    }
-
-    /* Recent activity / Pocket cards */
-    .card-outer {
-      --uc-border-radius: 8px;
-
-      &,
-      & .card,
-      & .ds-card-grid.ds-card-grid-border .ds-card:not(.placeholder) {
-        border-radius: var(--uc-border-radius) !important;
-      }
-
-      & .card,
-      & .ds-card-grid.ds-card-grid-border .ds-card:not(.placeholder) {
-        box-shadow:
-          rgb(0 0 0 / 0.14) 0px 1px 2px,
-          rgb(0 0 0 / 0.12) 0px 0px 2px !important;
-      }
-
-      & .card-preview-image-outer,
-      & .ds-card-grid.ds-card-grid-border .ds-card:not(.placeholder) .img-wrapper .img img {
-        border-radius: var(--uc-border-radius) var(--uc-border-radius) 0 0 !important
-      }
-    }
-
-    /* Add background & adjust padding for Recent activity & Pocket section. */
-    .collapsible-section:not(.top-sites) {
-      background-color: var(--newtab-background-color) !important;
-      border-radius: 12px !important;
-      padding: 10px 20px 20px !important;
-
-      & .section-list {
-        gap: 12px !important;
-      }
-    }
-
-    @media (-moz-bool-pref: "uc.tweak.hide-newtab-logo") {
-      .logo-and-wordmark {
-        display: none !important;
-      }
-
-      .outer-wrapper:not(.fixed-search) .search-wrapper {
-        padding-top: 0 !important;
-      }
-    }
-  }
-
-  /* private browsing newtab */
-  @-moz-document url-prefix(about:privatebrowsing) {
-    :root {
-      --uc-wordmark-color: light-dark(#737373, #fff);
-      --uc-background-color-secondary: light-dark(#fff, #4a4a4a);
-
-      @media (-moz-bool-pref: "browser.theme.dark-private-windows") {
-        color-scheme: dark !important;
-      }
-    }
-
-    /* Custom GTK colours. */
-    @media (-moz-gtk-csd-available) {
-      :root:not([lwt-newtab]):not([style*="color"]) {
-        /* Colour adjusted for readability. */
-        --uc-accent-adjusted: light-dark(color-mix(in oklch, AccentColor 92%, black), color-mix(in oklch, AccentColor 60%, white));
-        --in-content-page-background: light-dark(-moz-dialog, color-mix(in srgb, -moz-dialog 82%, black)) !important;
-        --uc-background-color-secondary: light-dark(Field, color-mix(in srgb, -moz-dialog 86%, white)) !important;
-        --in-content-page-color: -moz-dialogtext !important;
-        --in-content-focus-outline-color: var(--uc-accent-adjusted) !important;
-      }
-    }
-
-    /* Private browsing search bar. */
-    .search-inner-wrapper {
-      height: 44px !important;
       
-      .search-handoff-button,
-      .search-handoff-button:active,
-      .search-handoff-button:enabled:hover:active {
-        background-color: var(--uc-background-color-secondary) !important;
-        border: 0 !important;
-        border-radius: 99px !important;
-        padding-inline-start: 48px !important;
-        --elevation: 4;
-        box-shadow:
-        0 0 calc((var(--elevation) * 0.225px) + 2px) rgb(0 0 0 / .11),
-        0 calc(var(--elevation) * 0.4px) calc((var(--elevation) * 0.9px)) rgb(0 0 0 / .13) !important;
-        
-        &:hover {
-          --elevation: 6;
-        }
-        
-        &.focused:not(.disabled) {
-          box-shadow: none !important;
-          outline: 2px solid var(--in-content-focus-outline-color) !important;
-          outline-offset: -1px !important;
-        }
-        
-        &.disabled {
-          opacity: 0 !important;
-        }
-        
-        & .fake-textbox {
-          color: var(--in-content-page-color) !important;
-        }
+      & .fake-textbox {
+        color: var(--in-content-page-color) !important;
       }
     }
-
-    .wordmark {
-      fill: var(--uc-wordmark-color) !important;
-    }
-
-    /* Information box in private browsing. */
-    .info {
-      background-color: var(--uc-background-color-secondary) !important;
-      background-image: none !important;
-      position: relative !important;
-
-      /* Private browsing icon. */
-      &::before {
-        content: "";
-        position: absolute;
-        left: 32px;
-        top: 20px;
-        height: 32px;
-        aspect-ratio: 1 / 1;
-        background: center / contain url("../icons/account-private.svg");
-        border-radius: 99px;
-      }
-    }
-
   }
 
-  @media (-moz-bool-pref: "uc.tweak.newtab-background") {
-    @-moz-document url(about:newtab),
-    url(about:home),
-    url(about:privatebrowsing) {
-      body {
-        /* Specify both jpg and png file extensions, but jpg images will always
-        * have a higher priority. */
-        --bg-0: url(../background-0.jpg), url(../background-0.png);
-        --bg-1: url(../background-1.jpg), url(../background-1.png);
-        --newtab-element-hover-color: rgb(239 239 239 / .3) !important;
-        --newtab-element-active-color: rgb(239 239 239 / .45) !important;
-        --text-shadow: 0 1px 2px #000;
-        --icon-shadow: drop-shadow(0 0.3px 0.6px #000);
-        background-color: #252525 !important;
-        background-image: var(--bg-0) !important;
-        background-position: center !important;
-        background-size: cover !important;
-        background-attachment: fixed !important;
+  .wordmark {
+    fill: var(--uc-wordmark-color) !important;
+  }
 
-        :root[lwt-newtab-brighttext] &,
+  /* Information box in private browsing. */
+  .info {
+    background-color: var(--uc-background-color-secondary) !important;
+    background-image: none !important;
+    position: relative !important;
+
+    /* Private browsing icon. */
+    &::before {
+      content: "";
+      position: absolute;
+      left: 32px;
+      top: 20px;
+      height: 32px;
+      aspect-ratio: 1 / 1;
+      background: center / contain url("../icons/account-private.svg");
+      border-radius: 99px;
+    }
+  }
+
+}
+
+@media (-moz-bool-pref: "uc.tweak.newtab-background") {
+  @-moz-document url(about:newtab),
+  url(about:home),
+  url(about:privatebrowsing) {
+    body {
+      /* Specify both jpg and png file extensions, but jpg images will always
+      * have a higher priority. */
+      --bg-0: url(../background-0.jpg), url(../background-0.png);
+      --bg-1: url(../background-1.jpg), url(../background-1.png);
+      --newtab-element-hover-color: rgb(239 239 239 / .3) !important;
+      --newtab-element-active-color: rgb(239 239 239 / .45) !important;
+      --text-shadow: 0 1px 2px #000;
+      --icon-shadow: drop-shadow(0 0.3px 0.6px #000);
+      background-color: #252525 !important;
+      background-image: var(--bg-0) !important;
+      background-position: center !important;
+      background-size: cover !important;
+      background-attachment: fixed !important;
+
+      :root[lwt-newtab-brighttext] &,
+      :root.private & {
+        background-image: var(--bg-1), var(--bg-0) !important;
+        --newtab-element-hover-color: rgb(66 66 66 / .4) !important;
+        --newtab-element-active-color: rgb(66 66 66 / .55) !important;
+      }
+
+      @media not (-moz-bool-pref: "browser.theme.dark-private-windows") {
         :root.private & {
-          background-image: var(--bg-1), var(--bg-0) !important;
-          --newtab-element-hover-color: rgb(66 66 66 / .4) !important;
-          --newtab-element-active-color: rgb(66 66 66 / .55) !important;
-        }
+          background-image: var(--bg-0) !important;
 
-        @media not (-moz-bool-pref: "browser.theme.dark-private-windows") {
-          :root.private & {
-            background-image: var(--bg-0) !important;
-
-            @media (prefers-color-scheme: dark) {
-              background-image: var(--bg-1), var(--bg-0) !important;
-            }
+          @media (prefers-color-scheme: dark) {
+            background-image: var(--bg-1), var(--bg-0) !important;
           }
         }
       }
+    }
 
-      /* Change text colour & add backgrounds to text over the background. */
-      .top-site-outer .title {
-        text-shadow: var(--text-shadow) !important;
-        color: #fff !important;
-        -moz-osx-font-smoothing: auto !important;
-      }
+    /* Change text colour & add backgrounds to text over the background. */
+    .top-site-outer .title {
+      text-shadow: var(--text-shadow) !important;
+      color: #fff !important;
+      -moz-osx-font-smoothing: auto !important;
+    }
 
-      .wordmark,
-      .icon-settings,
-      .top-site-outer .context-menu-button {
-        filter: var(--icon-shadow) !important;
-        color: #fff !important;
-        fill: currentColor !important
-      }
+    .wordmark,
+    .icon-settings,
+    .top-site-outer .context-menu-button {
+      filter: var(--icon-shadow) !important;
+      color: #fff !important;
+      fill: currentColor !important
+    }
 
-      .top-site-outer .title .sponsored-label {
-        color: #eee !important;
-      }
+    .top-site-outer .title .sponsored-label {
+      color: #eee !important;
+    }
 
-      /* Add transparent sticky search header. */
-      @media (height > 700px) {
-        .fixed-search .search-wrapper {
-          border-bottom: 0 !important;
-          background: transparent linear-gradient(#0004, transparent) !important;
-        }
+    /* Add transparent sticky search header. */
+    @media (height > 700px) {
+      .fixed-search .search-wrapper {
+        border-bottom: 0 !important;
+        background: transparent linear-gradient(#0004, transparent) !important;
       }
     }
   }

--- a/chrome/content/newtab.css
+++ b/chrome/content/newtab.css
@@ -1,393 +1,395 @@
 /* Edge-Frfox - content/newtab.css */
 
-@-moz-document url-prefix("about:newtab"),
-url-prefix("about:home"),
-url-prefix("about:firefoxview") {
-  :root:not([lwt-newtab], [lwt-newtab-brighttext]) {
-    --newtab-background-color: #F7F7F7 !important;
-    --newtab-background-color-secondary: #fff !important;
-    --newtab-text-primary-color: #252525 !important;
-    --newtab-primary-action-background: #0078D4 !important;
-    --newtab-text-secondary-color: color-mix(in srgb, var(--newtab-text-primary-color) 80%, transparent) !important;
-    --newtab-element-hover-color: color-mix(in srgb, var(--newtab-background-color) 95%, #000) !important;
-    --newtab-element-active-color: color-mix(in srgb, var(--newtab-background-color) 90%, #000) !important;
-    --newtab-element-secondary-color: color-mix(in srgb, currentColor 5%, transparent) !important;
-    --newtab-element-secondary-hover-color: color-mix(in srgb, currentColor 12%, transparent) !important;
-    --newtab-element-secondary-active-color: color-mix(in srgb, currentColor 25%, transparent) !important;
-    --newtab-primary-element-hover-color: color-mix(in srgb, var(--newtab-primary-action-background) 90%, #000) !important;
-    --newtab-primary-element-active-color: color-mix(in srgb, var(--newtab-primary-action-background) 80%, #000) !important;
-    --newtab-primary-element-text-color: #fff !important;
-    --newtab-primary-action-background-dimmed: color-mix(in srgb, var(--newtab-primary-action-background) 25%, transparent) !important;
-    --newtab-border-color: color-mix(in srgb, var(--newtab-background-color) 75%, #000) !important;
-    --newtab-wordmark-color: #737373 !important;
-    --newtab-status-success: #50B080 !important;
-    --newtab-status-error: #FF848A !important;
-    --newtab-inner-box-shadow-color: rgb(0 0 0 / .1) !important;
-    --newtab-overlay-color: color-mix(in srgb, var(--newtab-background-color) 85%, transparent) !important;
-    --newtab-text-emphasis-background: #FFED32 !important;
-    --newtab-text-emphasis-text-color: #000 !important;
-    --newtab-textbox-focus-color: var(--newtab-primary-action-background) !important;
-    --newtab-textbox-focus-boxshadow: 0 0 0 1px var(--newtab-primary-action-background), 0 0 0 4px rgba(var(--newtab-primary-action-background), 0.3) !important;
-    --newtab-button-secondary-color: inherit !important;
-  }
-
-  :root:not([style*="color"])[lwt-newtab-brighttext] {
-    --newtab-background-color: #252525 !important;
-    --newtab-background-color-secondary: #4A4A4A !important;
-    --newtab-text-primary-color: #fff !important;
-    --newtab-primary-action-background: #75B6E8 !important;
-    --newtab-element-hover-color: color-mix(in srgb, var(--newtab-background-color) 95%, #FFF) !important;
-    --newtab-element-active-color: color-mix(in srgb, var(--newtab-background-color) 90%, #FFF) !important;
-    --newtab-element-secondary-color: color-mix(in srgb, currentColor 10%, transparent) !important;
-    --newtab-element-secondary-hover-color: color-mix(in srgb, currentColor 17%, transparent) !important;
-    --newtab-element-secondary-active-color: color-mix(in srgb, currentColor 30%, transparent) !important;
-    --newtab-border-color: color-mix(in srgb, var(--newtab-background-color) 75%, #FFF) !important;
-    --newtab-primary-element-text-color: #252525 !important;
-    --newtab-wordmark-color: #fff !important;
-    --newtab-status-success: #50B080 !important;
-  }
-
-  /* Custom GTK colours. */
-  @media (-moz-gtk-csd-available) {
-    :root:not([lwt-newtab]):not([style*="color"]) {
-      /* Colour adjusted for readability. */
-      --uc-accent-adjusted: light-dark(color-mix(in oklch, AccentColor 92%, black), color-mix(in oklch, AccentColor 60%, white));
-      --newtab-background-color: light-dark(-moz-dialog, color-mix(in srgb, -moz-dialog 82%, black)) !important;
-      --newtab-background-color-secondary: light-dark(Field, color-mix(in srgb, -moz-dialog 86%, white)) !important;
-      --newtab-text-primary-color: -moz-dialogtext !important;
-      --newtab-wordmark-color: light-dark(color-mix(in srgb, -moz-dialogtext 65%, transparent), -moz-dialogtext) !important;
-      --newtab-primary-action-background: var(--uc-accent-adjusted) !important;
-    }
-  }
-
-  /* Adjustments for themes. */
-  :root[style*="--newtab-background-color"] {
-    /* Make the Firefox logo workmark follow text colour. */
-    --newtab-wordmark-color: color-mix(in srgb, var(--newtab-text-primary-color) 60%, var(--newtab-background-color)) !important;
-
-    /* If there is no secondary background, create one from other colours. */
-    &:not([style*="--newtab-background-color-secondary"]) {
-      --newtab-background-color-secondary: color-mix(in srgb, var(--newtab-background-color) 15%, white) !important;
+@media (-moz-bool-pref: 'af.edgyarc.edge-styles') {
+  @-moz-document url-prefix("about:newtab"),
+  url-prefix("about:home"),
+  url-prefix("about:firefoxview") {
+    :root:not([lwt-newtab], [lwt-newtab-brighttext]) {
+      --newtab-background-color: #F7F7F7 !important;
+      --newtab-background-color-secondary: #fff !important;
+      --newtab-text-primary-color: #252525 !important;
+      --newtab-primary-action-background: #0078D4 !important;
+      --newtab-text-secondary-color: color-mix(in srgb, var(--newtab-text-primary-color) 80%, transparent) !important;
+      --newtab-element-hover-color: color-mix(in srgb, var(--newtab-background-color) 95%, #000) !important;
+      --newtab-element-active-color: color-mix(in srgb, var(--newtab-background-color) 90%, #000) !important;
+      --newtab-element-secondary-color: color-mix(in srgb, currentColor 5%, transparent) !important;
+      --newtab-element-secondary-hover-color: color-mix(in srgb, currentColor 12%, transparent) !important;
+      --newtab-element-secondary-active-color: color-mix(in srgb, currentColor 25%, transparent) !important;
+      --newtab-primary-element-hover-color: color-mix(in srgb, var(--newtab-primary-action-background) 90%, #000) !important;
+      --newtab-primary-element-active-color: color-mix(in srgb, var(--newtab-primary-action-background) 80%, #000) !important;
+      --newtab-primary-element-text-color: #fff !important;
+      --newtab-primary-action-background-dimmed: color-mix(in srgb, var(--newtab-primary-action-background) 25%, transparent) !important;
+      --newtab-border-color: color-mix(in srgb, var(--newtab-background-color) 75%, #000) !important;
+      --newtab-wordmark-color: #737373 !important;
+      --newtab-status-success: #50B080 !important;
+      --newtab-status-error: #FF848A !important;
+      --newtab-inner-box-shadow-color: rgb(0 0 0 / .1) !important;
+      --newtab-overlay-color: color-mix(in srgb, var(--newtab-background-color) 85%, transparent) !important;
+      --newtab-text-emphasis-background: #FFED32 !important;
+      --newtab-text-emphasis-text-color: #000 !important;
+      --newtab-textbox-focus-color: var(--newtab-primary-action-background) !important;
+      --newtab-textbox-focus-boxshadow: 0 0 0 1px var(--newtab-primary-action-background), 0 0 0 4px rgba(var(--newtab-primary-action-background), 0.3) !important;
+      --newtab-button-secondary-color: inherit !important;
     }
 
-    /* Dark adjustments for themes. */
-    &[lwt-newtab-brighttext] {
+    :root:not([style*="color"])[lwt-newtab-brighttext] {
+      --newtab-background-color: #252525 !important;
+      --newtab-background-color-secondary: #4A4A4A !important;
+      --newtab-text-primary-color: #fff !important;
+      --newtab-primary-action-background: #75B6E8 !important;
+      --newtab-element-hover-color: color-mix(in srgb, var(--newtab-background-color) 95%, #FFF) !important;
+      --newtab-element-active-color: color-mix(in srgb, var(--newtab-background-color) 90%, #FFF) !important;
+      --newtab-element-secondary-color: color-mix(in srgb, currentColor 10%, transparent) !important;
+      --newtab-element-secondary-hover-color: color-mix(in srgb, currentColor 17%, transparent) !important;
+      --newtab-element-secondary-active-color: color-mix(in srgb, currentColor 30%, transparent) !important;
+      --newtab-border-color: color-mix(in srgb, var(--newtab-background-color) 75%, #FFF) !important;
+      --newtab-primary-element-text-color: #252525 !important;
+      --newtab-wordmark-color: #fff !important;
+      --newtab-status-success: #50B080 !important;
+    }
+
+    /* Custom GTK colours. */
+    @media (-moz-gtk-csd-available) {
+      :root:not([lwt-newtab]):not([style*="color"]) {
+        /* Colour adjusted for readability. */
+        --uc-accent-adjusted: light-dark(color-mix(in oklch, AccentColor 92%, black), color-mix(in oklch, AccentColor 60%, white));
+        --newtab-background-color: light-dark(-moz-dialog, color-mix(in srgb, -moz-dialog 82%, black)) !important;
+        --newtab-background-color-secondary: light-dark(Field, color-mix(in srgb, -moz-dialog 86%, white)) !important;
+        --newtab-text-primary-color: -moz-dialogtext !important;
+        --newtab-wordmark-color: light-dark(color-mix(in srgb, -moz-dialogtext 65%, transparent), -moz-dialogtext) !important;
+        --newtab-primary-action-background: var(--uc-accent-adjusted) !important;
+      }
+    }
+
+    /* Adjustments for themes. */
+    :root[style*="--newtab-background-color"] {
       /* Make the Firefox logo workmark follow text colour. */
-      --newtab-wordmark-color: var(--newtab-text-primary-color) !important;
+      --newtab-wordmark-color: color-mix(in srgb, var(--newtab-text-primary-color) 60%, var(--newtab-background-color)) !important;
 
       /* If there is no secondary background, create one from other colours. */
       &:not([style*="--newtab-background-color-secondary"]) {
-        --newtab-background-color-secondary: color-mix(in srgb, var(--newtab-text-primary-color) 15%, var(--newtab-background-color)) !important;
+        --newtab-background-color-secondary: color-mix(in srgb, var(--newtab-background-color) 15%, white) !important;
       }
-    }
-  }
-}
 
-@-moz-document url-prefix("about:newtab"),
-url-prefix("about:home") {
-  /* Enforce system font selection. */
-  :where(body) {
-    font-family: system-ui !important;
-  }
+      /* Dark adjustments for themes. */
+      &[lwt-newtab-brighttext] {
+        /* Make the Firefox logo workmark follow text colour. */
+        --newtab-wordmark-color: var(--newtab-text-primary-color) !important;
 
-  /* Hide pin icons. */
-  .icon.icon-pin-small {
-    display: none !important;
-  }
-
-  /* Unpinned sites have lower opacity titles. */
-  .top-site-button .title:not(.pinned) {
-    opacity: 0.7 !important;
-  }
-
-  /* Search bar. */
-  .search-wrapper {
-    & .search-handoff-button {
-      border-radius: 99px !important;
-      background-position: 12px !important;
-      padding-inline-start: 48px !important;
-      white-space: nowrap !important;
-      text-overflow: ellipsis !important;
-      --elevation: 4;
-      box-shadow:
-        0 0 calc((var(--elevation) * 0.225px) + 2px) rgb(0 0 0 / .11),
-        0 calc(var(--elevation) * 0.4px) calc((var(--elevation) * 0.9px)) rgb(0 0 0 / .13) !important;
-
-      &:hover {
-        --elevation: 6;
-      }
-    }
-
-    & .search-inner-wrapper {
-      min-height: 44px !important;
-    }
-
-    &.fake-focus:not(.search.disabled) .search-handoff-button {
-      border-color: transparent !important;
-      outline: 2px solid var(--newtab-primary-action-background) !important;
-      outline-offset: -1px !important;
-    }
-
-    &.search-disabled .search-handoff-button {
-      opacity: 0 !important;
-    }
-
-    .search-handoff-button .fake-caret {
-      inset-inline-start: 48px !important;
-      top: 13px !important;
-    }
-
-    @media (height > 700px) {
-      .fixed-search & {
-        padding: 15px 0 !important;
-        min-height: auto !important;
-        border-bottom: none !important;
-      }
-    }
-  }
-
-  .fake-textbox {
-    overflow: hidden !important;
-    text-overflow: ellipsis !important;
-  }
-
-  .outer-wrapper.only-search {
-    display: flex !important;
-    padding: 30px !important;
-  }
-
-  /* Sticky search bar header when scrolling. */
-  @media (height > 700px) {
-    body:not(.inline-onboarding) .fixed-search.visible-logo main {
-      padding-top: 246px !important;
-
-      @media (-moz-bool-pref: "uc.tweak.hide-newtab-logo") {
-        padding-top: 82px !important;
-      }
-    }
-  }
-
-  .icon-settings {
-    background-image: url("../icons/settings.svg") !important;
-  }
-
-  /* Top sites tiles. */
-  .top-site-outer {
-    & .tile {
-      border-radius: 12px !important;
-      height: 44px !important;
-      width: 44px !important;
-      box-shadow: rgb(0 0 0 / 0.1) 0px 2px 4px !important;
-
-      & .icon-wrapper {
-        border-radius: 4px !important;
-        width: 24px !important;
-        height: 24px !important;
-
-        &.letter-fallback::before {
-          font-size: 32px !important;
+        /* If there is no secondary background, create one from other colours. */
+        &:not([style*="--newtab-background-color-secondary"]) {
+          --newtab-background-color-secondary: color-mix(in srgb, var(--newtab-text-primary-color) 15%, var(--newtab-background-color)) !important;
         }
       }
     }
-
-    & .default-icon,
-    & .search-topsite {
-      background-size: 16px !important;
-      height: 24px !important;
-      width: 24px !important;
-    }
   }
 
-  /* Recent activity / Pocket cards */
-  .card-outer {
-    --uc-border-radius: 8px;
-
-    &,
-    & .card,
-    & .ds-card-grid.ds-card-grid-border .ds-card:not(.placeholder) {
-      border-radius: var(--uc-border-radius) !important;
+  @-moz-document url-prefix("about:newtab"),
+  url-prefix("about:home") {
+    /* Enforce system font selection. */
+    :where(body) {
+      font-family: system-ui !important;
     }
 
-    & .card,
-    & .ds-card-grid.ds-card-grid-border .ds-card:not(.placeholder) {
-      box-shadow:
-        rgb(0 0 0 / 0.14) 0px 1px 2px,
-        rgb(0 0 0 / 0.12) 0px 0px 2px !important;
-    }
-
-    & .card-preview-image-outer,
-    & .ds-card-grid.ds-card-grid-border .ds-card:not(.placeholder) .img-wrapper .img img {
-      border-radius: var(--uc-border-radius) var(--uc-border-radius) 0 0 !important
-    }
-  }
-
-  /* Add background & adjust padding for Recent activity & Pocket section. */
-  .collapsible-section:not(.top-sites) {
-    background-color: var(--newtab-background-color) !important;
-    border-radius: 12px !important;
-    padding: 10px 20px 20px !important;
-
-    & .section-list {
-      gap: 12px !important;
-    }
-  }
-
-  @media (-moz-bool-pref: "uc.tweak.hide-newtab-logo") {
-    .logo-and-wordmark {
+    /* Hide pin icons. */
+    .icon.icon-pin-small {
       display: none !important;
     }
 
-    .outer-wrapper:not(.fixed-search) .search-wrapper {
-      padding-top: 0 !important;
+    /* Unpinned sites have lower opacity titles. */
+    .top-site-button .title:not(.pinned) {
+      opacity: 0.7 !important;
     }
-  }
-}
 
-/* private browsing newtab */
-@-moz-document url-prefix(about:privatebrowsing) {
-  :root {
-    --uc-wordmark-color: light-dark(#737373, #fff);
-    --uc-background-color-secondary: light-dark(#fff, #4a4a4a);
+    /* Search bar. */
+    .search-wrapper {
+      & .search-handoff-button {
+        border-radius: 99px !important;
+        background-position: 12px !important;
+        padding-inline-start: 48px !important;
+        white-space: nowrap !important;
+        text-overflow: ellipsis !important;
+        --elevation: 4;
+        box-shadow:
+          0 0 calc((var(--elevation) * 0.225px) + 2px) rgb(0 0 0 / .11),
+          0 calc(var(--elevation) * 0.4px) calc((var(--elevation) * 0.9px)) rgb(0 0 0 / .13) !important;
 
-    @media (-moz-bool-pref: "browser.theme.dark-private-windows") {
-      color-scheme: dark !important;
-    }
-  }
-
-  /* Custom GTK colours. */
-  @media (-moz-gtk-csd-available) {
-    :root:not([lwt-newtab]):not([style*="color"]) {
-      /* Colour adjusted for readability. */
-      --uc-accent-adjusted: light-dark(color-mix(in oklch, AccentColor 92%, black), color-mix(in oklch, AccentColor 60%, white));
-      --in-content-page-background: light-dark(-moz-dialog, color-mix(in srgb, -moz-dialog 82%, black)) !important;
-      --uc-background-color-secondary: light-dark(Field, color-mix(in srgb, -moz-dialog 86%, white)) !important;
-      --in-content-page-color: -moz-dialogtext !important;
-      --in-content-focus-outline-color: var(--uc-accent-adjusted) !important;
-    }
-  }
-
-  /* Private browsing search bar. */
-  .search-inner-wrapper {
-    height: 44px !important;
-    
-    .search-handoff-button,
-    .search-handoff-button:active,
-    .search-handoff-button:enabled:hover:active {
-      background-color: var(--uc-background-color-secondary) !important;
-      border: 0 !important;
-      border-radius: 99px !important;
-      padding-inline-start: 48px !important;
-      --elevation: 4;
-      box-shadow:
-      0 0 calc((var(--elevation) * 0.225px) + 2px) rgb(0 0 0 / .11),
-      0 calc(var(--elevation) * 0.4px) calc((var(--elevation) * 0.9px)) rgb(0 0 0 / .13) !important;
-      
-      &:hover {
-        --elevation: 6;
+        &:hover {
+          --elevation: 6;
+        }
       }
-      
-      &.focused:not(.disabled) {
-        box-shadow: none !important;
-        outline: 2px solid var(--in-content-focus-outline-color) !important;
+
+      & .search-inner-wrapper {
+        min-height: 44px !important;
+      }
+
+      &.fake-focus:not(.search.disabled) .search-handoff-button {
+        border-color: transparent !important;
+        outline: 2px solid var(--newtab-primary-action-background) !important;
         outline-offset: -1px !important;
       }
-      
-      &.disabled {
+
+      &.search-disabled .search-handoff-button {
         opacity: 0 !important;
       }
-      
-      & .fake-textbox {
-        color: var(--in-content-page-color) !important;
-      }
-    }
-  }
 
-  .wordmark {
-    fill: var(--uc-wordmark-color) !important;
-  }
-
-  /* Information box in private browsing. */
-  .info {
-    background-color: var(--uc-background-color-secondary) !important;
-    background-image: none !important;
-    position: relative !important;
-
-    /* Private browsing icon. */
-    &::before {
-      content: "";
-      position: absolute;
-      left: 32px;
-      top: 20px;
-      height: 32px;
-      aspect-ratio: 1 / 1;
-      background: center / contain url("../icons/account-private.svg");
-      border-radius: 99px;
-    }
-  }
-
-}
-
-@media (-moz-bool-pref: "uc.tweak.newtab-background") {
-  @-moz-document url(about:newtab),
-  url(about:home),
-  url(about:privatebrowsing) {
-    body {
-      /* Specify both jpg and png file extensions, but jpg images will always
-       * have a higher priority. */
-      --bg-0: url(../background-0.jpg), url(../background-0.png);
-      --bg-1: url(../background-1.jpg), url(../background-1.png);
-      --newtab-element-hover-color: rgb(239 239 239 / .3) !important;
-      --newtab-element-active-color: rgb(239 239 239 / .45) !important;
-      --text-shadow: 0 1px 2px #000;
-      --icon-shadow: drop-shadow(0 0.3px 0.6px #000);
-      background-color: #252525 !important;
-      background-image: var(--bg-0) !important;
-      background-position: center !important;
-      background-size: cover !important;
-      background-attachment: fixed !important;
-
-      :root[lwt-newtab-brighttext] &,
-      :root.private & {
-        background-image: var(--bg-1), var(--bg-0) !important;
-        --newtab-element-hover-color: rgb(66 66 66 / .4) !important;
-        --newtab-element-active-color: rgb(66 66 66 / .55) !important;
+      .search-handoff-button .fake-caret {
+        inset-inline-start: 48px !important;
+        top: 13px !important;
       }
 
-      @media not (-moz-bool-pref: "browser.theme.dark-private-windows") {
-        :root.private & {
-          background-image: var(--bg-0) !important;
-
-          @media (prefers-color-scheme: dark) {
-            background-image: var(--bg-1), var(--bg-0) !important;
-          }
+      @media (height > 700px) {
+        .fixed-search & {
+          padding: 15px 0 !important;
+          min-height: auto !important;
+          border-bottom: none !important;
         }
       }
     }
 
-    /* Change text colour & add backgrounds to text over the background. */
-    .top-site-outer .title {
-      text-shadow: var(--text-shadow) !important;
-      color: #fff !important;
-      -moz-osx-font-smoothing: auto !important;
+    .fake-textbox {
+      overflow: hidden !important;
+      text-overflow: ellipsis !important;
     }
 
-    .wordmark,
-    .icon-settings,
-    .top-site-outer .context-menu-button {
-      filter: var(--icon-shadow) !important;
-      color: #fff !important;
-      fill: currentColor !important
+    .outer-wrapper.only-search {
+      display: flex !important;
+      padding: 30px !important;
     }
 
-    .top-site-outer .title .sponsored-label {
-      color: #eee !important;
-    }
-
-    /* Add transparent sticky search header. */
+    /* Sticky search bar header when scrolling. */
     @media (height > 700px) {
-      .fixed-search .search-wrapper {
-        border-bottom: 0 !important;
-        background: transparent linear-gradient(#0004, transparent) !important;
+      body:not(.inline-onboarding) .fixed-search.visible-logo main {
+        padding-top: 246px !important;
+
+        @media (-moz-bool-pref: "uc.tweak.hide-newtab-logo") {
+          padding-top: 82px !important;
+        }
+      }
+    }
+
+    .icon-settings {
+      background-image: url("../icons/settings.svg") !important;
+    }
+
+    /* Top sites tiles. */
+    .top-site-outer {
+      & .tile {
+        border-radius: 12px !important;
+        height: 44px !important;
+        width: 44px !important;
+        box-shadow: rgb(0 0 0 / 0.1) 0px 2px 4px !important;
+
+        & .icon-wrapper {
+          border-radius: 4px !important;
+          width: 24px !important;
+          height: 24px !important;
+
+          &.letter-fallback::before {
+            font-size: 32px !important;
+          }
+        }
+      }
+
+      & .default-icon,
+      & .search-topsite {
+        background-size: 16px !important;
+        height: 24px !important;
+        width: 24px !important;
+      }
+    }
+
+    /* Recent activity / Pocket cards */
+    .card-outer {
+      --uc-border-radius: 8px;
+
+      &,
+      & .card,
+      & .ds-card-grid.ds-card-grid-border .ds-card:not(.placeholder) {
+        border-radius: var(--uc-border-radius) !important;
+      }
+
+      & .card,
+      & .ds-card-grid.ds-card-grid-border .ds-card:not(.placeholder) {
+        box-shadow:
+          rgb(0 0 0 / 0.14) 0px 1px 2px,
+          rgb(0 0 0 / 0.12) 0px 0px 2px !important;
+      }
+
+      & .card-preview-image-outer,
+      & .ds-card-grid.ds-card-grid-border .ds-card:not(.placeholder) .img-wrapper .img img {
+        border-radius: var(--uc-border-radius) var(--uc-border-radius) 0 0 !important
+      }
+    }
+
+    /* Add background & adjust padding for Recent activity & Pocket section. */
+    .collapsible-section:not(.top-sites) {
+      background-color: var(--newtab-background-color) !important;
+      border-radius: 12px !important;
+      padding: 10px 20px 20px !important;
+
+      & .section-list {
+        gap: 12px !important;
+      }
+    }
+
+    @media (-moz-bool-pref: "uc.tweak.hide-newtab-logo") {
+      .logo-and-wordmark {
+        display: none !important;
+      }
+
+      .outer-wrapper:not(.fixed-search) .search-wrapper {
+        padding-top: 0 !important;
+      }
+    }
+  }
+
+  /* private browsing newtab */
+  @-moz-document url-prefix(about:privatebrowsing) {
+    :root {
+      --uc-wordmark-color: light-dark(#737373, #fff);
+      --uc-background-color-secondary: light-dark(#fff, #4a4a4a);
+
+      @media (-moz-bool-pref: "browser.theme.dark-private-windows") {
+        color-scheme: dark !important;
+      }
+    }
+
+    /* Custom GTK colours. */
+    @media (-moz-gtk-csd-available) {
+      :root:not([lwt-newtab]):not([style*="color"]) {
+        /* Colour adjusted for readability. */
+        --uc-accent-adjusted: light-dark(color-mix(in oklch, AccentColor 92%, black), color-mix(in oklch, AccentColor 60%, white));
+        --in-content-page-background: light-dark(-moz-dialog, color-mix(in srgb, -moz-dialog 82%, black)) !important;
+        --uc-background-color-secondary: light-dark(Field, color-mix(in srgb, -moz-dialog 86%, white)) !important;
+        --in-content-page-color: -moz-dialogtext !important;
+        --in-content-focus-outline-color: var(--uc-accent-adjusted) !important;
+      }
+    }
+
+    /* Private browsing search bar. */
+    .search-inner-wrapper {
+      height: 44px !important;
+      
+      .search-handoff-button,
+      .search-handoff-button:active,
+      .search-handoff-button:enabled:hover:active {
+        background-color: var(--uc-background-color-secondary) !important;
+        border: 0 !important;
+        border-radius: 99px !important;
+        padding-inline-start: 48px !important;
+        --elevation: 4;
+        box-shadow:
+        0 0 calc((var(--elevation) * 0.225px) + 2px) rgb(0 0 0 / .11),
+        0 calc(var(--elevation) * 0.4px) calc((var(--elevation) * 0.9px)) rgb(0 0 0 / .13) !important;
+        
+        &:hover {
+          --elevation: 6;
+        }
+        
+        &.focused:not(.disabled) {
+          box-shadow: none !important;
+          outline: 2px solid var(--in-content-focus-outline-color) !important;
+          outline-offset: -1px !important;
+        }
+        
+        &.disabled {
+          opacity: 0 !important;
+        }
+        
+        & .fake-textbox {
+          color: var(--in-content-page-color) !important;
+        }
+      }
+    }
+
+    .wordmark {
+      fill: var(--uc-wordmark-color) !important;
+    }
+
+    /* Information box in private browsing. */
+    .info {
+      background-color: var(--uc-background-color-secondary) !important;
+      background-image: none !important;
+      position: relative !important;
+
+      /* Private browsing icon. */
+      &::before {
+        content: "";
+        position: absolute;
+        left: 32px;
+        top: 20px;
+        height: 32px;
+        aspect-ratio: 1 / 1;
+        background: center / contain url("../icons/account-private.svg");
+        border-radius: 99px;
+      }
+    }
+
+  }
+
+  @media (-moz-bool-pref: "uc.tweak.newtab-background") {
+    @-moz-document url(about:newtab),
+    url(about:home),
+    url(about:privatebrowsing) {
+      body {
+        /* Specify both jpg and png file extensions, but jpg images will always
+        * have a higher priority. */
+        --bg-0: url(../background-0.jpg), url(../background-0.png);
+        --bg-1: url(../background-1.jpg), url(../background-1.png);
+        --newtab-element-hover-color: rgb(239 239 239 / .3) !important;
+        --newtab-element-active-color: rgb(239 239 239 / .45) !important;
+        --text-shadow: 0 1px 2px #000;
+        --icon-shadow: drop-shadow(0 0.3px 0.6px #000);
+        background-color: #252525 !important;
+        background-image: var(--bg-0) !important;
+        background-position: center !important;
+        background-size: cover !important;
+        background-attachment: fixed !important;
+
+        :root[lwt-newtab-brighttext] &,
+        :root.private & {
+          background-image: var(--bg-1), var(--bg-0) !important;
+          --newtab-element-hover-color: rgb(66 66 66 / .4) !important;
+          --newtab-element-active-color: rgb(66 66 66 / .55) !important;
+        }
+
+        @media not (-moz-bool-pref: "browser.theme.dark-private-windows") {
+          :root.private & {
+            background-image: var(--bg-0) !important;
+
+            @media (prefers-color-scheme: dark) {
+              background-image: var(--bg-1), var(--bg-0) !important;
+            }
+          }
+        }
+      }
+
+      /* Change text colour & add backgrounds to text over the background. */
+      .top-site-outer .title {
+        text-shadow: var(--text-shadow) !important;
+        color: #fff !important;
+        -moz-osx-font-smoothing: auto !important;
+      }
+
+      .wordmark,
+      .icon-settings,
+      .top-site-outer .context-menu-button {
+        filter: var(--icon-shadow) !important;
+        color: #fff !important;
+        fill: currentColor !important
+      }
+
+      .top-site-outer .title .sponsored-label {
+        color: #eee !important;
+      }
+
+      /* Add transparent sticky search header. */
+      @media (height > 700px) {
+        .fixed-search .search-wrapper {
+          border-bottom: 0 !important;
+          background: transparent linear-gradient(#0004, transparent) !important;
+        }
       }
     }
   }

--- a/chrome/toolbar/findbar.css
+++ b/chrome/toolbar/findbar.css
@@ -56,7 +56,7 @@ findbar .close-icon {
 @media (-moz-bool-pref: "uc.tweak.rounded-corners") {
   findbar {
     border: none !important;
-    margin-bottom: var(--uc-tweak-rounded-corners-padding, 0px) !important;
+    margin-top: calc(-1 * var(--uc-tweak-rounded-corners-padding, 0px)) !important;
     background-color: transparent !important;
     padding-inline: var(--uc-tweak-rounded-corners-padding, 0px) !important;
 

--- a/chrome/userContent.css
+++ b/chrome/userContent.css
@@ -1,5 +1,5 @@
 /* Edge-Frfox */
-@import url("content/common.css") (-moz-bool-pref: 'af.edgyarc.edge-styles');
-@import url("content/newtab.css") (-moz-bool-pref: 'af.edgyarc.edge-styles');
+@import url("content/common.css") (-moz-bool-pref: "af.edgyarc.edge-styles");
+@import url("content/newtab.css") (-moz-bool-pref: "af.edgyarc.edge-styles");
 @import url("tweaks/sidebery.css") (-moz-bool-pref: "uc.tweak.theme.sidebery");
 @import url("EdgyArc-fr/sidebery.css") (-moz-bool-pref: "af.sidebery.edgyarc-theme");

--- a/chrome/userContent.css
+++ b/chrome/userContent.css
@@ -1,5 +1,5 @@
 /* Edge-Frfox */
-@import url("content/common.css");
-@import url("content/newtab.css");
+@import url("content/common.css") (-moz-bool-pref: 'af.edgyarc.edge-styles');
+@import url("content/newtab.css") (-moz-bool-pref: 'af.edgyarc.edge-styles');
 @import url("tweaks/sidebery.css") (-moz-bool-pref: "uc.tweak.theme.sidebery");
 @import url("EdgyArc-fr/sidebery.css") (-moz-bool-pref: "af.sidebery.edgyarc-theme");


### PR DESCRIPTION
- Added an option to disable content border (closes #51). I opted for `var(--uc-tweak-rounded-corners-shadow)`. Feature flag is `af.edgyarc.no-content-border`
- Added an option to disable edge styles (closes #53). Feature flag is `af.edgyarc.edge-styles`
- Fixed margins, made paddings around findbar smaller (see comparison)
<img width="337" alt="image" src="https://github.com/artsyfriedchicken/EdgyArc-fr/assets/21295738/bf8752c5-f619-4b84-8d1d-cddbb43f6cd6">
<img width="315" alt="image" src="https://github.com/artsyfriedchicken/EdgyArc-fr/assets/21295738/0197a8f1-213e-4ec0-a1e7-e58860f58e93">

Suggestions welcome (especially whether my new feature flags should be on or off by default)