### PR TITLE
Fix content borders for Firefox v132.0

### DIFF
--- a/chrome/global/browser.css
+++ b/chrome/global/browser.css
@@ -88,7 +88,7 @@
   }
 
   /* Apply rounded corners to the browser container. */
-  #appcontent .browserStack {
+  #browser .browserStack {
     margin-inline: var(--uc-tweak-rounded-corners-padding) !important;
     margin-block-end: var(--uc-tweak-rounded-corners-padding) !important;
     border-radius: var(--uc-tweak-rounded-corners-radius) !important;


### PR DESCRIPTION
### Overview
- This fix addresses issue https://github.com/artsyfriedchicken/EdgyArc-fr/issues/80, where Firefox version 132 would not render the the borders around the content area.
- Credits to @peterahn8 for the solution.
### Changes
- Changed the CSS selector for `.browserStack` from `#appcontent` to `#browser` to restore border configurations for the content area.