### PR TITLE
Fixes for FF133 - Sidebar and windows titlebar buttons

### DIFF
--- a/chrome/EdgyArc-fr/autohide-sidebar-modified.css
+++ b/chrome/EdgyArc-fr/autohide-sidebar-modified.css
@@ -35,7 +35,7 @@ See the above repository for updates as well as full license text. */
     min-width: var(--uc-sidebar-width) !important;
     width: var(--uc-sidebar-width) !important;
     max-width: var(--uc-sidebar-width) !important;
-    z-index: 1;
+    z-index: 3;
     @media not (-moz-bool-pref:"uc.tweak.af.sidebar-width-350") {--uc-sidebar-hover-width: 260px;}
     @media (-moz-bool-pref:"uc.tweak.af.sidebar-width-350") {--uc-sidebar-hover-width: 350px;}
   }

--- a/chrome/tweaks/hide-tabs-bar.css
+++ b/chrome/tweaks/hide-tabs-bar.css
@@ -74,7 +74,8 @@
   @media (-moz-platform: windows) {
     /* Offset navbar contents to make space for the window controls */
     &:where([inFullscreen], [tabsintitlebar]) #nav-bar {
-      padding-inline-end: calc(140px + var(--uc-titlebar-drag-space)) !important;
+      padding-inline-end: 0px;
+      margin-inline-end: calc(140px + var(--uc-titlebar-drag-space)) !important;
 
       /* Remove the padding from the side of the navbar */
       & #PanelUI-menu-button {


### PR DESCRIPTION
- Fix sidebar z-index so it doesn't hide behind content
- Fix for windows 11 minimize, close buttons getting hidden under nav bar padding and becoming unclickable